### PR TITLE
Add "masters = gentoo" to metadata/layout.conf to avoid portage warning

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -2,3 +2,4 @@ update-changelog = false
 thin-manifests = true
 sign-manifests = false
 sign-commits = true
+masters = gentoo


### PR DESCRIPTION
Add "masters = gentoo" to metadata/layout.conf to avoid portage warning
