### PR TITLE
remove dependency on some unneeded qt packages

### DIFF
--- a/sci-electronics/pulseview/pulseview-9999.ebuild
+++ b/sci-electronics/pulseview/pulseview-9999.ebuild
@@ -45,5 +45,10 @@ src_configure() {
 	else
 		mycmakeargs+=( -DSTATIC_PKGDEPS_LIBS=FALSE )
 	fi
+	if use sigrokdecode; then
+		mycmakeargs+=( -DENABLE_DECODE=TRUE )
+	else
+		mycmakeargs+=( -DENABLE_DECODE=FALSE )
+	fi
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
replace dependency on whole qt toolkit with required packages only

This removes dependency on wast amount of unneeded packages.
