### PR TITLE
Fix name of enable flag for sigrokdecode

### DIFF
--- a/sci-electronics/pulseview/pulseview-9999.ebuild
+++ b/sci-electronics/pulseview/pulseview-9999.ebuild
@@ -38,7 +38,7 @@ src_configure() {
 	# TODO: test support via ENABLE_TESTS
 	local mycmakeargs=(
 		-DDISABLE_WERROR=TRUE
-		$(cmake-utils_use_enable sigrokdecode)
+		$(cmake-utils_use_enable sigrokdecode DECODE)
 	)
 	if use static; then
 		mycmakeargs+=( -DSTATIC_PKGDEPS_LIBS=TRUE )


### PR DESCRIPTION
The PulseView CMake enable flag for sigrokdecode is called `ENABLE_DECODE`, not `ENABLE_SIGROKDECODE`.  Because of this, the use flag "sigrokdecode" does not enable sigrokdecode support like it should.  This commit fixes the problem by setting the correct enable flag.
